### PR TITLE
Simpler serial reader

### DIFF
--- a/gp.py
+++ b/gp.py
@@ -226,7 +226,7 @@ class GP(threading.Thread):
         paths = list_devices()
         for device_path in paths:
             device = InputDevice(device_path)
-            if device.name == "Pro Controller":
+            if "Pro" in device.name:
                 self.device_path = device_path
                 self.device = device
                 print(

--- a/server.py
+++ b/server.py
@@ -2,7 +2,9 @@ import flask
 import os
 import eventlet
 from flask_socketio import SocketIO, emit
-from utils.serial_helpers import SerialReaderWriter
+from utils.serial_helpers2 import SerialReaderWriter
+
+# from utils.serial_helpers import SerialReaderWriter
 from utils.radio_helpers.client_side import ClientEelState
 from utils.radio_helpers.eel_side import CommandMessage, from_json_to_state
 from utils.radio_helpers.utils import to_json_filtered

--- a/utils/serial_helpers2.py
+++ b/utils/serial_helpers2.py
@@ -1,0 +1,52 @@
+import serial
+import time
+from typing import Callable
+import threading
+
+SLEEP_TIME = 0.01
+
+
+class SerialReaderWriter:
+    def __init__(
+        self,
+        port: str,
+        baudrate: int = 19200,
+        timeout: int = 1,
+        on_message: Callable[[str], None] = None,
+    ):
+        self._ser = serial.serial_for_url(port, baudrate=baudrate, timeout=timeout)
+        self._on_message = on_message
+        self._ser.flush()
+        self._ser.reset_input_buffer()
+        self._ser.reset_output_buffer()
+        self.thread = threading.Thread(target=self._loop, daemon=True)
+        self.thread.start()
+
+    def send(self, message):
+        self._write_one_message(message)
+
+    # TODO: remove or use? it could be interesting to see if there's ever anything in in_waiting or out_waiting
+    # def _flush_if_necessary(self):
+    #     in_waiting = self._ser.in_waiting
+    #     out_waiting = self._ser.out_waiting
+    #     if in_waiting > 0 or out_waiting > 0:
+    #         print("in_waiting", in_waiting, "out_waiting", out_waiting)
+    #         self._ser.flush()
+
+    def _write_one_message(self, message):
+        msg_line = "{}\n".format(message)
+        self._ser.write(bytes(msg_line, "utf-8"))
+        self._ser.flush()
+        # TODO: remove or use?
+        # self._flush_if_necessary()
+
+    def _loop(self):
+        while True:
+            msg = self._ser.readline()
+            if msg:
+                self._on_message(msg.decode("utf-8").strip())
+
+            self._ser.flush()
+            # TODO: remove or use?
+            # self._flush_if_necessary()
+            time.sleep(SLEEP_TIME)


### PR DESCRIPTION
Basically the same as in https://github.com/foxpoint-se/eel/pull/13

---

See:
```
# from ..utils.serial_helpers import SerialReaderWriter
from ..utils.serial_helpers2 import SerialReaderWriter
```
Added a different threaded serial reader (serial_helpers2), much less complicated than the previous one. This one flushes after every read and every write, as well as in constructor. Hopefully it works better because of all the flushing, but we need to test. At least it works in simulation mode. If it doesn't work, I hope it will be easier for us to tweak because of the simpler implementation.

All the other changes are the ones we did when testing last time.
